### PR TITLE
Android Fix for WebView 47+

### DIFF
--- a/Src/Android/com/coherentlabs/ui/CoherentAndroidViewBridge.java
+++ b/Src/Android/com/coherentlabs/ui/CoherentAndroidViewBridge.java
@@ -30,6 +30,8 @@ public class CoherentAndroidViewBridge {
 
 	private Activity mActivity;
 	private WebView mWebView;
+	private CoherentWebViewClient mClient;
+	private CoherentAndroidViewBridge mBridge;
 	private boolean mIsTransparent;
 
 	public CoherentAndroidViewBridge(Activity activity) {
@@ -37,6 +39,7 @@ public class CoherentAndroidViewBridge {
 			Log.wtf(LOG_TAG, "Trying to create Coherent UI View with null activity!");
 		}
 
+		mBridge = this;
 		mActivity = activity;
 	}
 
@@ -165,10 +168,11 @@ public class CoherentAndroidViewBridge {
 				}
 
 				// WebViewClient must be set BEFORE calling loadUrl!
-				mWebView.setWebViewClient(new CoherentWebViewClient(mActivity, usesDefaultFileHandler));
+				mClient = new CoherentWebViewClient(mActivity, usesDefaultFileHandler);
+				mWebView.setWebViewClient(mClient);
 				mWebView.setWebChromeClient(new CoherentWebChromeClient());
 
-				mWebView.addJavascriptInterface(new CoherentJavaScriptInterface(mWebView), CoherentJavaScriptInterface.INTERFACE_NAME);
+				mWebView.addJavascriptInterface(new CoherentJavaScriptInterface(mWebView, mBridge), CoherentJavaScriptInterface.INTERFACE_NAME);
 
 				if (width != 0 && height != 0) {
 					mActivity.addContentView(mWebView,
@@ -366,6 +370,10 @@ public class CoherentAndroidViewBridge {
 				mWebView.setLayoutParams(params);
 			}
 		});
+	}
+	
+	public CoherentWebViewClient getWebViewClient(){
+		return mClient;
 	}
 
 	private native void notifySoftKeyboardVisible(boolean visible);

--- a/Src/Android/com/coherentlabs/ui/CoherentJavaScriptInterface.java
+++ b/Src/Android/com/coherentlabs/ui/CoherentJavaScriptInterface.java
@@ -7,10 +7,12 @@ import android.webkit.WebView;
 public class CoherentJavaScriptInterface {
 	public static final String INTERFACE_NAME = "__couiAndroid";
 	private WebView mWebView;
+	private CoherentAndroidViewBridge mBridge;
 	private float mDPtoPXCoef;
 
-	public CoherentJavaScriptInterface(WebView webView) {
+	public CoherentJavaScriptInterface(WebView webView, CoherentAndroidViewBridge bridge) {
 		mWebView = webView;
+		mBridge = bridge;
 		
 		DisplayMetrics displayMetrics = webView.getContext().getResources().getDisplayMetrics();
 		mDPtoPXCoef = displayMetrics.densityDpi / 160.0f;
@@ -27,4 +29,9 @@ public class CoherentJavaScriptInterface {
 	}
 	
 	public native void addCoherentTouchEvent(int id, int fingerId, int phase, int x, int y);
+	
+	@JavascriptInterface
+	public void triggerNativeCode(String event) {
+		this.mBridge.getWebViewClient().triggerNativeCode(mWebView.getId(), event);
+	}
 }

--- a/Src/Android/com/coherentlabs/ui/CoherentWebViewClient.java
+++ b/Src/Android/com/coherentlabs/ui/CoherentWebViewClient.java
@@ -30,12 +30,25 @@ public class CoherentWebViewClient extends WebViewClient {
 			Log.v(LOG_TAG, "Overriding URL loading of \"" + url + "\" for view " + view.getId());
 			return true;
 		} else {
+			// Workaround for Android 5+, because WebView 47+ does not call onLoadResource like the previous versions did.
+			// We could (or even should) be checking the WebView-Version here, but I didn't find a nice way to do that.
+			if (android.os.Build.VERSION.SDK_INT >= 21){
+				loadResourceDirect(view, url);
+			}
+			
 			return false;
 		}
 	}
 
 	@Override
 	public void onLoadResource(WebView view, String url) {
+	
+		if (android.os.Build.VERSION.SDK_INT < 21){
+			loadResourceDirect(view, url);
+		}
+	}
+	
+	private void loadResourceDirect(WebView view, String url){
 		if (url != null && url.startsWith("coherent-js")) {
 			triggerNativeCode(view.getId(), url);
 		}

--- a/Src/Android/com/coherentlabs/ui/CoherentWebViewClient.java
+++ b/Src/Android/com/coherentlabs/ui/CoherentWebViewClient.java
@@ -29,26 +29,13 @@ public class CoherentWebViewClient extends WebViewClient {
 		if (url != null && !shouldStartLoad(view.getId(), url)) {
 			Log.v(LOG_TAG, "Overriding URL loading of \"" + url + "\" for view " + view.getId());
 			return true;
-		} else {
-			// Workaround for Android 5+, because WebView 47+ does not call onLoadResource like the previous versions did.
-			// We could (or even should) be checking the WebView-Version here, but I didn't find a nice way to do that.
-			if (android.os.Build.VERSION.SDK_INT >= 21){
-				callTriggerNativeCode(view, url);
-			}
-			
+		} else {			
 			return false;
 		}
 	}
 
 	@Override
 	public void onLoadResource(WebView view, String url) {
-	
-		if (android.os.Build.VERSION.SDK_INT < 21){
-			callTriggerNativeCode(view, url);
-		}
-	}
-	
-	private void callTriggerNativeCode(WebView view, String url){
 		if (url != null && url.startsWith("coherent-js")) {
 			triggerNativeCode(view.getId(), url);
 		}

--- a/Src/Android/com/coherentlabs/ui/CoherentWebViewClient.java
+++ b/Src/Android/com/coherentlabs/ui/CoherentWebViewClient.java
@@ -33,7 +33,7 @@ public class CoherentWebViewClient extends WebViewClient {
 			// Workaround for Android 5+, because WebView 47+ does not call onLoadResource like the previous versions did.
 			// We could (or even should) be checking the WebView-Version here, but I didn't find a nice way to do that.
 			if (android.os.Build.VERSION.SDK_INT >= 21){
-				loadResourceDirect(view, url);
+				callTriggerNativeCode(view, url);
 			}
 			
 			return false;
@@ -44,11 +44,11 @@ public class CoherentWebViewClient extends WebViewClient {
 	public void onLoadResource(WebView view, String url) {
 	
 		if (android.os.Build.VERSION.SDK_INT < 21){
-			loadResourceDirect(view, url);
+			callTriggerNativeCode(view, url);
 		}
 	}
 	
-	private void loadResourceDirect(WebView view, String url){
+	private void callTriggerNativeCode(WebView view, String url){
 		if (url != null && url.startsWith("coherent-js")) {
 			triggerNativeCode(view.getId(), url);
 		}

--- a/UnityIntegration/Assets/WebPlayerTemplates/uiresources/MobileInput/javascript/coherent.js
+++ b/UnityIntegration/Assets/WebPlayerTemplates/uiresources/MobileInput/javascript/coherent.js
@@ -241,7 +241,7 @@
 	
 	var simpleEvent;
 
-	if(window.__couiAndroid == undefined) {
+	if (window.__couiAndroid == undefined) {
 		simpleEvent = function (type) {
 			return function () {
 				var prefix = ['coherent-js', type],
@@ -254,7 +254,7 @@
 				frame.parentNode.removeChild(frame);
 			};
 		};
-	}else{
+	} else {
 			simpleEvent = function (type) {
 			return function () {
 				var prefix = ['coherent-js', type];
@@ -391,7 +391,7 @@
 		var createSendMessage;
 		var createTriggerEvent;
 		
-		if(window.__couiAndroid == undefined) {
+		if (window.__couiAndroid == undefined) {
 		
 			var frame = document.createElement('iframe');
 			
@@ -418,7 +418,7 @@
 				};
 			};
 
-		}else{
+		} else {
 			createSendMessage = function () {
 				var prefix = 'coherent-js:c:';
 				return function () {

--- a/UnityIntegration/Assets/WebPlayerTemplates/uiresources/MobileInput/javascript/coherent.js
+++ b/UnityIntegration/Assets/WebPlayerTemplates/uiresources/MobileInput/javascript/coherent.js
@@ -238,22 +238,20 @@
 
 		return promise;
 	};
-
+	
 	var simpleEvent;
 
 	if(window.__couiAndroid == undefined) {
 		simpleEvent = function (type) {
-			return function () {			
+			return function () {
 				var prefix = ['coherent-js', type],
 					frame = document.createElement('iframe');
 				prefix.push.apply(prefix, arguments);
 				frame.src = prefix.join(':');
 				frame.width = '1px';
 				frame.height = '1px';
-				frame.style.display = 'none';
 				document.documentElement.appendChild(frame);
-				window.setTimeout(function(){frame.parentNode.removeChild(frame)}, 2000);
-
+				frame.parentNode.removeChild(frame);
 			};
 		};
 	}else{
@@ -264,10 +262,8 @@
 				__couiAndroid.triggerNativeCode(prefix.join(':'));
 			};
 		};
-	
-	
 	}
-	
+
 	if (engine === undefined)
 	{
 		if (window.__couiAndroid !== undefined && window.__couiAndroid.initCoui !== undefined)
@@ -282,7 +278,7 @@
 		{
 			simpleEvent('q')();
 		}
-
+		
 		engine = window.engine;
 	}
 
@@ -402,28 +398,23 @@
 			createSendMessage = function () {
 				var prefix = 'coherent-js:c:';
 				return function () {
-					var frame = document.createElement('iframe');
 					var json = JSON.stringify(toArray.call(arguments, 2));
 					frame.src = prefix + arguments[0] + ':' + arguments[1] + ':' + encodeURIComponent(json);
 					frame.width = '1px';
 					frame.height = '1px';
-					frame.style.display = 'none';
 					document.documentElement.appendChild(frame);
-					window.setTimeout(function(){frame.parentNode.removeChild(frame)}, 2000);
+					frame.parentNode.removeChild(frame);
 				};
 			};
-			
 			createTriggerEvent = function () {
 				var prefix = 'coherent-js:e:';
 				return function () {
-					var frame = document.createElement('iframe');
 					var json = JSON.stringify(toArray.call(arguments, 1));
 					frame.src = prefix + arguments[0] + ':' + encodeURIComponent(json);
 					frame.width = '1px';
 					frame.height = '1px';
-					frame.style.display = 'none';
 					document.documentElement.appendChild(frame);
-					window.setTimeout(function(){frame.parentNode.removeChild(frame)}, 2000);
+					frame.parentNode.removeChild(frame);
 				};
 			};
 
@@ -444,7 +435,6 @@
 				};
 			};
 		}
-		
 		engine.SendMessage = createSendMessage();
 		engine.TriggerEvent = createTriggerEvent();
 
@@ -455,7 +445,7 @@
 		};
 
 		var unload = simpleEvent('u');
-		var unloadEvent = ((window.__couiAndroid === undefined) ? 'unload' : 'beforeunload');
+		var unloadEvent = ((window.__couiAndroid === undefined) ? 'pagehide' : 'beforeunload');
 		window.addEventListener(unloadEvent, unload);
 
 		engine.__observeLifetime = function () {
@@ -492,12 +482,14 @@
 
 	engine._Result = function (requestId) {
 		var deferred = engine._ActiveRequests[requestId];
+		if (deferred !== undefined)
+		{
+			delete engine._ActiveRequests[requestId];
 
-		delete engine._ActiveRequests[requestId];
-
-		var resultArguments = Array.prototype.slice.call(arguments);
-		resultArguments.shift();
-		deferred.resolve.apply(deferred, resultArguments);
+			var resultArguments = Array.prototype.slice.call(arguments);
+			resultArguments.shift();
+			deferred.resolve.apply(deferred, resultArguments);
+		}
 	};
 
 	engine._Errors = [ 'Success', 'ArgumentType', 'NoSuchMethod', 'NoResult' ];
@@ -648,7 +640,7 @@
 				{
 					// Input state: Take none
 					event.preventDefault();
-
+					
 					var touches = event.changedTouches;
 					for (var i = 0; i < touches.length; ++i) {
 						window.__couiAndroid.addTouchEvent(Number(touches[i].identifier), phase, touches[i].screenX, touches[i].screenY);
@@ -667,20 +659,20 @@
 				}
 			};
 		};
-
+		
 		var setupCoherentForAndroidFunc = function() {
 			document.body.addEventListener('touchstart', touchListener(0));
 			document.body.addEventListener('touchend', touchListener(3));
 			document.body.addEventListener('touchcancel', touchListener(4));
 			document.body.addEventListener('touchmove', touchListener(1));
-
+			
 			var newdiv = document.createElement('div');
 			newdiv.setAttribute('id', '__CoherentBackground');
 			newdiv.setAttribute('class', 'coui-noinput');
 			newdiv.setAttribute('style', 'background-color: "rgba(0,0,0,0)";' +
 				'width: 100%; height: 100%; position: absolute;' +
 				'z-index: -1000000;');
-
+			
 			document.body.insertBefore(newdiv, document.body.firstChild);
 		};
 
@@ -690,7 +682,7 @@
 			document.addEventListener('DOMContentLoaded',
 				setupCoherentForAndroidFunc);
 		}
-	}
+	}	
 
 	if (hasOnLoad) {
 		global.onload = (function (originalWindowLoaded) {

--- a/UnityIntegration/Assets/WebPlayerTemplates/uiresources/MobileInput/javascript/coherent.js
+++ b/UnityIntegration/Assets/WebPlayerTemplates/uiresources/MobileInput/javascript/coherent.js
@@ -396,8 +396,10 @@
 		var createTriggerEvent;
 		
 		if(window.__couiAndroid == undefined) {
-
-			 createSendMessage = function () {
+		
+			var frame = document.createElement('iframe');
+			
+			createSendMessage = function () {
 				var prefix = 'coherent-js:c:';
 				return function () {
 					var frame = document.createElement('iframe');
@@ -434,7 +436,7 @@
 				};
 			};
 			
-			 createTriggerEvent = function () {
+			createTriggerEvent = function () {
 				var prefix = 'coherent-js:e:';
 				return function () {
 					var json = JSON.stringify(toArray.call(arguments, 1));


### PR DESCRIPTION
It seems like the communication between javascript and WebView via iframe is no longer reliable on Android devices running WebView Version 47+. Therefore I created a direct communication between javascript and WebView using the JavaScriptInterface. To keep the compatibility with iOS, I added a check in coherent.js if the __couiAndroid-Interface is defined. If not, the script uses an iframe for communication (like it did before).

My changes are related to this thread in the forum:
https://forums.coherent-labs.com/index.php/topic,1061.0.html
